### PR TITLE
Refactor(#13): Domain 모듈 형식 수정

### DIFF
--- a/app/src/main/java/com/example/todayfortune/di/ApiModule.kt
+++ b/app/src/main/java/com/example/todayfortune/di/ApiModule.kt
@@ -9,6 +9,7 @@ import dagger.hilt.components.SingletonComponent
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
 @Module
@@ -22,11 +23,21 @@ object ApiModule {
 
     @Singleton
     @Provides
-    fun provideRetrofit(okHttpClient: OkHttpClient): Retrofit {
+    fun retrofit(okHttpClient: OkHttpClient): Retrofit {
         return Retrofit.Builder()
             .baseUrl("https://base.api/")
             .client(okHttpClient)
             .addConverterFactory(GsonConverterFactory.create(GsonBuilder().setLenient().create()))
+            .build()
+    }
+
+    @Singleton
+    @Provides
+    fun okHttpClient(): OkHttpClient {
+        return OkHttpClient.Builder()
+            .connectTimeout(15, TimeUnit.SECONDS)
+            .readTimeout(15, TimeUnit.SECONDS)
+            .writeTimeout(15, TimeUnit.SECONDS)
             .build()
     }
 }

--- a/app/src/main/java/com/example/todayfortune/di/UseCaseModule.kt
+++ b/app/src/main/java/com/example/todayfortune/di/UseCaseModule.kt
@@ -1,0 +1,27 @@
+package com.example.todayfortune.di
+
+import com.example.domain.repository.TotalInfoRepository
+import com.example.domain.usecase.FetchTotalInfoUsecase
+import com.example.domain.usecase.GetTotalInfoUsecase
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+object UseCaseModule {
+    @Provides
+    fun fetchTotalInfoUsecase(
+        totalInfoRepository: TotalInfoRepository
+    ): FetchTotalInfoUsecase {
+        return FetchTotalInfoUsecase(totalInfoRepository)
+    }
+
+    @Provides
+    fun getTotalInfoUsecase(
+        totalInfoRepository: TotalInfoRepository
+    ): GetTotalInfoUsecase {
+        return GetTotalInfoUsecase(totalInfoRepository)
+    }
+}


### PR DESCRIPTION
클린 아키텍처에서 `Domain Layer`는 최상위 layer로, 다른 모든 layer 및 안드로이드 라이브러리에 대해 종속성을 가지지 않는 것을 지향한다.
이를 위해 `Domain Layer`의 모듈 템플릿을 Android Library가 아닌 Java&Kotlin Library로 설정하였고, Hilt를 사용하지 않는 방식으로 구현하였다.

이러한 방식을 사용하였을 때 아래와 같은 문제점이 발생하였다.
- `Domain Layer` 내 `UseCase` 호출 시 `Data Layer`에서 구현된 `Repository` 주입 불가

따라서 문제점을 해결하기 위해 모든 layer에 대해 종속성을 가지고 있는 `App Module`에 `UsecaseModule.kt`를 추가한다.
- `Domain Layer`의 모듈 형식은 그대로 유지 -> 종속성 최소화 유지
- `App Module`에 `UsecaseModule` 추가하여 `UseCase`에 대한 `Repository` 객체 주입 -> `Repository` 주입 불가 문제 해결

-- `Domain Layer`를 Android Library 템플릿으로 설정하고 Hilt를 사용하는 것과, 위의 방식대로 구현하는 것 중 어떤 것이 더 효율적일지는 확인이 필요하다.

-- ~~테스트 진행 시, 템플릿을 Android Library로 설정하지 않으면 test 모듈을 별도로 생성해줘야 하는 번거로움이 있다.~~